### PR TITLE
Add 'area/controller' repository label

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -1,6 +1,9 @@
 - name: 'area/compute'
   color: 'C5DEF5'
 
+- name: 'area/controller'
+  color: 'C5DEF5'
+
 - name: 'area/iam'
   color: 'C5DEF5'
 


### PR DESCRIPTION
Adds new `area/controller` label to reference for core repository issues related to the Kubernetes controller framework itself.